### PR TITLE
HAWK-761 log connection error

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -290,8 +290,8 @@ if __name__ == '__main__':
                     else:
                         info("Running on slave, waiting for promotion...")
                         time.sleep(60)
-        except Exception:
-            error("Unable to connect postgres server, retrying in 60sec...")
+        except Exception as e:
+            error(f"Unable to connect to postgres server: {e}, retrying in 60sec...")
             time.sleep(60)
 
     # Launch exporter
@@ -303,4 +303,3 @@ if __name__ == '__main__':
     ticker = threading.Event()
     while not ticker.wait(update_basebackup_interval):
         exporter.update_basebackup()
-


### PR DESCRIPTION
Example output:
```bash
$ ./wal-g-prometheus-exporter /tmp/
INFO:root:Startup...
INFO:root:My PID is: 2960043
INFO:root:Webserver started on port 9351
ERROR:root:Unable to connect to postgres server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
, retrying in 60sec...

```