### PR TITLE
upgrade centos 7 -> 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build exporter
-FROM centos:7 AS exporter-builder
+FROM centos:8 AS exporter-builder
 
 WORKDIR /usr/src/
 ADD https://www.python.org/ftp/python/3.7.5/Python-3.7.5.tgz  /usr/src/


### PR DESCRIPTION
This will give us libpq version 13 instead of 9.
It will support SCRAM authentication.